### PR TITLE
updated lock_password() to handle null passwords

### DIFF
--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -221,7 +221,7 @@ def lock_password(name):
     pre_info = info(name)
     if pre_info['name'] == '':
         return False
-    if pre_info['passwd'][0] == '!':
+    if pre_info['passwd'].startswith('!'):
         return True
 
     cmd = 'passwd -l {0}'.format(name)
@@ -229,7 +229,7 @@ def lock_password(name):
 
     post_info = info(name)
 
-    return post_info['passwd'][0] == '!'
+    return post_info['passwd'].startswith('!')
 
 
 def unlock_password(name):


### PR DESCRIPTION

### What does this PR do?
Uses string.startswith('!') instead of array notation string[0] == '!' to check for ! at the beginning of the passwd field

### What issues does this PR fix or reference?
issue #45141

### Previous Behavior
Throws a IndexError: string index out of range for null passwords

### New Behavior
Continues as expected by locking passwords

### Tests written?
No

### Commits signed with GPG?
No

